### PR TITLE
Fix for Mac

### DIFF
--- a/bin/rbenv-clean
+++ b/bin/rbenv-clean
@@ -9,7 +9,7 @@ set -e
 uninstall() {
     list=`gem list --no-versions`
     for gem in $list; do
-        gem uninstall $gem -aIx
+        gem uninstall $gem -aIx || true
     done
     gem list
     gem install bundler


### PR DESCRIPTION
```rbenv clean``` can´t continue uninstalling gems after one uninstallation fails. Adding a ``` || true ```condition solves the problem.

- System: OSX
